### PR TITLE
Fix Firefox not submitting update form

### DIFF
--- a/web/scripts/main.js
+++ b/web/scripts/main.js
@@ -1,9 +1,14 @@
 $(document).ready(function() {
-    $("#update").on('click', function() {
+    $("#update").on('click', function(e) {
+        // If we let the form submission process at the same time, Firefox will
+        // fail the request with NS_BINDING_ABORTED
+        e.preventDefault();
+        
         var bg = $("#bg").val();
         var mode = $("#mode").val();
         var state = $("#state").val();
         var id = $("#userid").val();
+        var form = $(this).parent();
         $.ajax({
             url: "/update",
             method: "GET",
@@ -16,6 +21,7 @@ $(document).ready(function() {
             },
             success: function(data) {
                 $("#response").html(data);
+                form.submit();
             },
         });
     });


### PR DESCRIPTION
If you're going to hook into a form button, you need to preventDefault or weird bugs happen. Firefox users can't change their state at all at the moment. This should fix it.

(Why isn't the update form like... an actual form that's POSTed like a form?)